### PR TITLE
fix: iam APIs starts from index 0

### DIFF
--- a/src/apis/iamClient.test.ts
+++ b/src/apis/iamClient.test.ts
@@ -41,7 +41,7 @@ suite('IAM Internal Client', () => {
       method: 'GET',
       query: {
         per_page: '200',
-        page: '1',
+        page: '0',
         identityType: 'type',
       },
     }).reply(200, mockedResult)
@@ -56,7 +56,7 @@ suite('IAM Internal Client', () => {
       method: 'GET',
       query: {
         per_page: '200',
-        page: '1',
+        page: '0',
       },
     }).reply(500, { error: 'Internal Server Error' })
 
@@ -73,7 +73,7 @@ suite('IAM Internal Client', () => {
       method: 'GET',
       query: {
         per_page: '200',
-        page: '1',
+        page: '0',
         from: '0000000000000000',
         to: '9999999999999999',
       },
@@ -89,7 +89,7 @@ suite('IAM Internal Client', () => {
       method: 'GET',
       query: {
         per_page: '200',
-        page: '1',
+        page: '0',
       },
     }).reply(500, { error: 'Internal Server Error' })
 
@@ -118,7 +118,7 @@ suite('IAM Client', () => {
       method: 'GET',
       query: {
         per_page: '200',
-        page: '1',
+        page: '0',
         identityType: 'type',
       },
     }).reply(200, mockedResult)
@@ -137,7 +137,7 @@ suite('IAM Client', () => {
       method: 'GET',
       query: {
         per_page: '200',
-        page: '1',
+        page: '0',
         from: '0000000000000000',
         to: '9999999999999999',
       },

--- a/src/apis/iamClient.ts
+++ b/src/apis/iamClient.ts
@@ -42,7 +42,7 @@ export class IAMClient {
       ...type && { identityType: type },
     })
 
-    return this.#client.getPaginated<Record<string, unknown>>(this.#companyIAMPath(tenantID), params)
+    return this.#client.getPaginated<Record<string, unknown>>(this.#companyIAMPath(tenantID), params, 0)
   }
 
   companyAuditLogs (tenantID: string, from?: string, to?: string): Promise<Record<string, unknown>[]> {
@@ -51,7 +51,7 @@ export class IAMClient {
       ...to && { to },
     })
 
-    return this.#client.getPaginated<Record<string, unknown>>(this.#companyAuditLogsPath(tenantID), params)
+    return this.#client.getPaginated<Record<string, unknown>>(this.#companyAuditLogsPath(tenantID), params, 0)
   }
 
   #companyIAMPath (tenantID: string): string {


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

Solved an issue where the APIs dedicated to the IAM (i.e., users and audit logs) starts from index 1 instead of index 0.
<!--
Describe what this PR is trying to achieve, for example is this a PR that fix an open issue? Is for a new feature? etc.
-->

