### PR TITLE
Adds error flag to tool call results

### DIFF
--- a/src/tools/deploy/index.test.ts
+++ b/src/tools/deploy/index.test.ts
@@ -103,6 +103,7 @@ suite('deploy project tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error deploying project: ${expectedError}`,
@@ -147,6 +148,7 @@ suite('deploy project tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error deploying project: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -231,6 +233,7 @@ suite('deploy project tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error deploying project: error message',
@@ -276,6 +279,7 @@ suite('compare_update_for_deploy tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error retrieving configuration updates: ${expectedError}`,
@@ -320,6 +324,7 @@ suite('compare_update_for_deploy tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error retrieving configuration updates: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -402,6 +407,7 @@ suite('compare_update_for_deploy tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error retrieving configuration updates: error message',
@@ -445,6 +451,7 @@ suite('deploy_pipeline_status tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error deploying project: ${expectedError}`,
@@ -485,6 +492,7 @@ suite('deploy_pipeline_status tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error deploying project: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -559,6 +567,7 @@ suite('deploy_pipeline_status tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error deploying project: error message',

--- a/src/tools/deploy/index.ts
+++ b/src/tools/deploy/index.ts
@@ -54,6 +54,7 @@ export function addDeployCapabilities (server: McpServer, client: IAPIClient) {
               text: `Error deploying project: ${err.message}`,
             },
           ],
+          isError: true,
         }
       }
     },
@@ -91,6 +92,7 @@ export function addDeployCapabilities (server: McpServer, client: IAPIClient) {
               text: `Error retrieving configuration updates: ${err.message}`,
             },
           ],
+          isError: true,
         }
       }
     },
@@ -127,6 +129,7 @@ export function addDeployCapabilities (server: McpServer, client: IAPIClient) {
               text: `Error deploying project: ${err.message}`,
             },
           ],
+          isError: true,
         }
       }
     },

--- a/src/tools/governance/index.test.ts
+++ b/src/tools/governance/index.test.ts
@@ -158,6 +158,7 @@ suite('projects list tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching projects for ${testTenantIds.join(', ')}: ${ERR_AI_FEATURES_NOT_ENABLED_MULTIPLE_TENANTS}`,
@@ -214,6 +215,7 @@ suite('projects list tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching projects for ${testTenantIds.join(', ')}: error message`,
@@ -254,6 +256,7 @@ suite('get project info', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching project ${testProjectId}: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -328,6 +331,7 @@ suite('get project info', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching project error: error message',
@@ -362,6 +366,7 @@ suite('create project from template', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating project from template templateID: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -416,6 +421,7 @@ suite('create project from template', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.equal(result.isError, true)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error creating project from template templateID: error message',

--- a/src/tools/governance/index.ts
+++ b/src/tools/governance/index.ts
@@ -80,6 +80,7 @@ export function addGovernanceCapabilities (server: McpServer, client: IAPIClient
               text: `Error fetching projects for ${tenantIds.join(', ')}: ${err.message}`,
             },
           ],
+          isError: true,
         }
       }
     },
@@ -113,6 +114,7 @@ export function addGovernanceCapabilities (server: McpServer, client: IAPIClient
               text: `Error fetching project ${projectId}: ${err.message}`,
             },
           ],
+          isError: true,
         }
       }
     },
@@ -149,6 +151,7 @@ export function addGovernanceCapabilities (server: McpServer, client: IAPIClient
               text: `Error creating project from template ${templateId}: ${err.message}`,
             },
           ],
+          isError: true,
         }
       }
     },


### PR DESCRIPTION
Ensures that error responses from the deploy and governance tools correctly indicate an error status. This ensures that calling applications can reliably determine if a tool execution resulted in an error.
