### PR TITLE
feat: use dotenv to import environment variables in application

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ npm ci
 npm run build
 ```
 
-These commands will install all the dependencies and then transpile the typescript code in the `build` folder.  
+These commands will install all the dependencies and then transpile the typescript code in the `build` folder.
+
+> [!NOTE]
+> The server automatically loads environment variables from a `.env` file if present in the project root. 
+> You can create one by copying `default.env` to `.env` and updating the values as needed.
+
 Once these steps are completed you can setup the MCP server using the `node` command like the following:
 
 ```json
@@ -66,6 +71,9 @@ Once these steps are completed you can setup the MCP server using the `node` com
 }
 ```
 
+> [!TIP]
+> If you have a `.env` file configured with your credentials, you can omit the `env` section from the configuration above as the server will automatically load the environment variables.
+
 ## Local Development
 
 To help with the development of the server you need Node.js installed on your machine.  
@@ -78,7 +86,7 @@ following command:
 npm ci
 ```
 
-Once has finished you will have all the dependencies installed on the project, then you have to prepare an environent
+Once has finished you will have all the dependencies installed on the project, then you have to prepare an environment
 file by copying the default.env file and edit it accordingly.
 
 ```sh
@@ -88,7 +96,6 @@ cp default.env .env
 Finally to verify everything works, run:
 
 ```sh
-set -a && source .env
 npm run local:test
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mia-platform/console-types": "^0.38.8",
         "@modelcontextprotocol/sdk": "^1.15.0",
         "commander": "^14.0.0",
+        "dotenv": "^17.2.1",
         "fastify": "^5.4.0",
         "undici": "^7.11.0",
         "zod": "^3.25.76"
@@ -1447,6 +1448,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mia-platform/console-types": "^0.38.8",
         "@modelcontextprotocol/sdk": "^1.15.0",
         "commander": "^14.0.0",
-        "dotenv": "^17.2.1",
+        "dotenv": "^17.2.2",
         "fastify": "^5.4.0",
         "undici": "^7.11.0",
         "zod": "^3.25.76"
@@ -1451,9 +1451,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@mia-platform/console-types": "^0.38.8",
     "@modelcontextprotocol/sdk": "^1.15.0",
     "commander": "^14.0.0",
-    "dotenv": "^17.2.1",
+    "dotenv": "^17.2.2",
     "fastify": "^5.4.0",
     "undici": "^7.11.0",
     "zod": "^3.25.76"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@mia-platform/console-types": "^0.38.8",
     "@modelcontextprotocol/sdk": "^1.15.0",
     "commander": "^14.0.0",
+    "dotenv": "^17.2.1",
     "fastify": "^5.4.0",
     "undici": "^7.11.0",
     "zod": "^3.25.76"

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ import { httpServer } from './server/httpserver'
 import { runStdioServer } from './server/stdio'
 import { description, version } from '../package.json'
 
+import 'dotenv/config'
+
 const program = new Command()
 
 program.
@@ -33,7 +35,7 @@ program.
   description('start the Mia-Platform Console MCP Server').
   option('--stdio', 'run the server in stdio mode (default when using npx)', false).
   option('--server-host <serverHost>', 'host to expose the server on', '0.0.0.0').
-  addOption(new Option('-p, --port <port>', 'port to run the server on').default('3000').env('HTTP_PORT')).
+  addOption(new Option('-p, --port <port>', 'port to run the server on').env('HTTP_PORT').default('3000')).
   addOption(new Option('--host <host>', 'Mia-Platform Console host').env('CONSOLE_HOST')).
   action(({ host, stdio, port, serverHost }) => {
     const clientID = process.env.MIA_PLATFORM_CLIENT_ID || ''


### PR DESCRIPTION
## What this PR is for?

Adds `dotenv` to the list of dependencies for automatic discovery and retrieval of environment variables stored in the `.env` file.

I've also updated the README.md file to include instruction on how the `.env` file is automatically loaded.

