### PR TITLE
fix(view_audit_logs): params "from" and "to" now accept regular dates

### DIFF
--- a/src/apis/iamClient.test.ts
+++ b/src/apis/iamClient.test.ts
@@ -21,6 +21,8 @@ import { IAMClient, IAMClientInternal, internalEndpoint } from './iamClient'
 
 const tenantId = 'test-tenant-id'
 
+process.env.TZ = 'UTC'
+
 suite('IAM Internal Client', () => {
   const client = IAMClientInternal('', '')
   let agent: MockAgent
@@ -99,7 +101,7 @@ suite('IAM Internal Client', () => {
       },
     }).reply(200, mockedResult)
 
-    const result = await client.companyAuditLogs(tenantId, '2024-03-11T12:00:00', '2024-03-11T12:30:00')
+    const result = await client.companyAuditLogs(tenantId, '2024-03-11T11:00:00', '2024-03-11T11:30:00')
     t.assert.deepStrictEqual(result, mockedResult)
   })
 
@@ -183,7 +185,7 @@ suite('IAM Client', () => {
       },
     }).reply(200, mockedResult)
 
-    const result = await client.companyAuditLogs(tenantId, '2024-03-11T12:00:00', '2024-03-11T12:30:00')
+    const result = await client.companyAuditLogs(tenantId, '2024-03-11T11:00:00', '2024-03-11T11:30:00')
     t.assert.deepStrictEqual(result, mockedResult)
   })
 })

--- a/src/apis/iamClient.test.ts
+++ b/src/apis/iamClient.test.ts
@@ -74,12 +74,32 @@ suite('IAM Internal Client', () => {
       query: {
         per_page: '200',
         page: '0',
-        from: '0000000000000000',
-        to: '9999999999999999',
+        from: '1710154800000',
+        to: '1710156600000',
       },
     }).reply(200, mockedResult)
 
-    const result = await client.companyAuditLogs(tenantId, '0000000000000000', '9999999999999999')
+    const result = await client.companyAuditLogs(tenantId, '1710154800000', '1710156600000')
+    t.assert.deepStrictEqual(result, mockedResult)
+  })
+
+  test('list company audit logs with dates as a filter', async (t: TestContext) => {
+    const mockedResult = [
+      { id: 'identity1', type: 'user', name: 'User 1' },
+    ]
+
+    agent.get(internalEndpoint).intercept({
+      path: `/tenants/${tenantId}/audit-logs`,
+      method: 'GET',
+      query: {
+        per_page: '200',
+        page: '0',
+        from: '1710154800000',
+        to: '1710156600000',
+      },
+    }).reply(200, mockedResult)
+
+    const result = await client.companyAuditLogs(tenantId, '2024-03-11T12:00:00', '2024-03-11T12:30:00')
     t.assert.deepStrictEqual(result, mockedResult)
   })
 
@@ -127,7 +147,7 @@ suite('IAM Client', () => {
     t.assert.deepStrictEqual(result, mockedResult)
   })
 
-  test('list company audit logs', async (t: TestContext) => {
+  test('list company audit logs with unix timestamps as a filter', async (t: TestContext) => {
     const mockedResult = [
       { id: 'identity1', type: 'user', name: 'User 1' },
     ]
@@ -138,12 +158,32 @@ suite('IAM Client', () => {
       query: {
         per_page: '200',
         page: '0',
-        from: '0000000000000000',
-        to: '9999999999999999',
+        from: '1710154800000',
+        to: '1710156600000',
       },
     }).reply(200, mockedResult)
 
-    const result = await client.companyAuditLogs(tenantId, '0000000000000000', '9999999999999999')
+    const result = await client.companyAuditLogs(tenantId, '1710154800000', '1710156600000')
+    t.assert.deepStrictEqual(result, mockedResult)
+  })
+
+  test('list company audit logs with dates as a filter', async (t: TestContext) => {
+    const mockedResult = [
+      { id: 'identity1', type: 'user', name: 'User 1' },
+    ]
+
+    agent.get(mockedEndpoint).intercept({
+      path: `/api/tenants/${tenantId}/audit-logs`,
+      method: 'GET',
+      query: {
+        per_page: '200',
+        page: '0',
+        from: '1710154800000',
+        to: '1710156600000',
+      },
+    }).reply(200, mockedResult)
+
+    const result = await client.companyAuditLogs(tenantId, '2024-03-11T12:00:00', '2024-03-11T12:30:00')
     t.assert.deepStrictEqual(result, mockedResult)
   })
 })

--- a/src/apis/iamClient.ts
+++ b/src/apis/iamClient.ts
@@ -15,6 +15,7 @@
 
 import { UndiciHeaders } from 'undici/types/dispatcher'
 
+import { formatQueryParamToUnixTimestamp } from './utils'
 import { HTTPClient } from './http-client'
 
 export const internalEndpoint = process.env.IAM_INTERNAL_ENDPOINT || 'http://internal.local:3000'
@@ -47,8 +48,8 @@ export class IAMClient {
 
   companyAuditLogs (tenantID: string, from?: string, to?: string): Promise<Record<string, unknown>[]> {
     const params = new URLSearchParams({
-      ...from && { from },
-      ...to && { to },
+      ...from && { from: formatQueryParamToUnixTimestamp(from) },
+      ...to && { to: formatQueryParamToUnixTimestamp(to) },
     })
 
     return this.#client.getPaginated<Record<string, unknown>>(this.#companyAuditLogsPath(tenantID), params, 0)

--- a/src/apis/utils.test.ts
+++ b/src/apis/utils.test.ts
@@ -1,0 +1,45 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { suite, test, TestContext } from 'node:test'
+
+import { formatQueryParamToUnixTimestamp } from './utils'
+
+suite('formatQueryParamToUnixTimestamp', () => {
+  test('should return undefined for undefined input', (t: TestContext) => {
+    t.assert.equal(formatQueryParamToUnixTimestamp(undefined), undefined)
+  })
+
+  test('should throw error for invalid date format', (t: TestContext) => {
+    t.assert.throws(
+      () => formatQueryParamToUnixTimestamp('invalid-date'),
+      { message: 'Invalid date format: invalid-date' },
+    )
+  })
+
+  test('should handle different valid date formats', (t: TestContext) => {
+    const testCases = [
+      { input: '2023-12-31', expected: '1703980800000' },
+      { input: '2023-06-15T12:30:00+02:00', expected: '1686825000000' },
+      { input: '2023-06-15T10:30:00Z', expected: '1686825000000' },
+      { input: '2023-06-15T10:30:00.000Z', expected: '1686825000000' },
+      { input: '2023-06-15T10:30:00.000+00:00', expected: '1686825000000' },
+    ]
+
+    for (const { input, expected } of testCases) {
+      t.assert.equal(formatQueryParamToUnixTimestamp(input), expected, `Failed for input: ${input} (expected: ${expected})`)
+    }
+  })
+})

--- a/src/apis/utils.ts
+++ b/src/apis/utils.ts
@@ -1,0 +1,39 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Transform a date string into a Unix timestamp in milliseconds.
+ * The result is parsed into a string to be used as a query parameter.
+ *
+ * @param param a date string in ISO 8601 format or YYYY-MM-DD format.
+ * @returns the Unix timestamp in milliseconds as a string, or undefined if the input is undefined.
+ */
+export function formatQueryParamToUnixTimestamp (param: string | undefined): string | undefined {
+  if (!param) {
+    return undefined
+  }
+
+  let date = new Date(Number(param))
+  if (isNaN(date.getTime())) {
+    date = new Date(param)
+  }
+
+  if (isNaN(date.getTime())) {
+    console.log({ param, date, time: date.getTime() })
+    throw new Error(`Invalid date format: ${param}`)
+  }
+
+  return date.getTime().toString()
+}

--- a/src/tools/descriptions.ts
+++ b/src/tools/descriptions.ts
@@ -111,8 +111,8 @@ export const paramsDescriptions = {
   IAM_IDENTITY_TYPE: 'Filter the IAM entities by type',
 
   // Audit Logs
-  AUDIT_LOG_FROM: 'The start date of the audit logs to fetch, in unix timestamp format',
-  AUDIT_LOG_TO: 'The end date of the audit logs to fetch, in unix timestamp format',
+  AUDIT_LOG_FROM: 'The start date of the audit logs to fetch, in ISO 8601 format (YYYY-MM-DDTHH:mm:ss), e.g., "2024-01-15T10:30:00"',
+  AUDIT_LOG_TO: 'The end date of the audit logs to fetch, in ISO 8601 format (YYYY-MM-DDTHH:mm:ss), e.g., "2024-01-15T23:59:59"',
 
   // Marketplace
   MARKETPLACE_ITEM_ID: `The marketplace item to use to create the service. Can be found in the itemId field of the ${toolNames.LIST_MARKETPLACE} tool`,


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

<!--
Describe what this PR is trying to achieve, for example is this a PR that fix an open issue? Is for a new feature? etc.
-->

This PR includes some updates on the `view_audit_logs` tool, to broaden the type of parameters allowed by filters `from` and `to`. While it was required a Unix Timestamp, now it allows JS dates (following the ISO 8601) that we will transform into timestamps.

This update should solve the issue most client have to add the correct timestamp for both the `from` and `to` filter of the tool. In this way it should be easier to include correct date and solve the issue sometimes caused by the LLM to include erroneous dates giving wrong results.

