### PR TITLE
feat: support for MCP prompts, created "deploy" prompt

### DIFF
--- a/src/prompts/deploy.test.ts
+++ b/src/prompts/deploy.test.ts
@@ -1,0 +1,124 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from 'node:assert'
+import { beforeEach, suite, test } from 'node:test'
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { GetPromptResultSchema, ListPromptsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+
+import { addDeployPrompt } from './deploy'
+import { TestMCPServer } from '../server/utils.test'
+
+suite('setup deploy prompt', () => {
+  let client: Client
+  beforeEach(async () => {
+    client = await TestMCPServer((server) => {
+      addDeployPrompt(server)
+    })
+  })
+
+  test('the prompt is included in the list of prompts', async () => {
+    const result = await client.request(
+      {
+        method: 'prompts/list',
+      },
+      ListPromptsResultSchema,
+    )
+
+    assert.equal(result.prompts.length, 1)
+  })
+
+  test('the prompt is retrieved with the requested parameters', async () => {
+    const result = await client.request(
+      {
+        method: 'prompts/get',
+        params: {
+          name: 'deploy',
+          arguments: {
+            tenant: 'my-tenant',
+            project: 'my-project',
+            environment: 'my-environment',
+          },
+        },
+      },
+      GetPromptResultSchema,
+    )
+
+    assert.equal(result.messages.length, 3)
+    const [ firstUserMessage, firstAssistantMessage, secondUserMessage ] = result.messages
+    assert.equal(firstUserMessage.role, 'user')
+    assert.equal(firstAssistantMessage.role, 'assistant')
+    assert.equal(secondUserMessage.role, 'user')
+
+    const firstUserMessageText = firstUserMessage.content.text
+    if (typeof firstUserMessageText !== 'string') {
+      assert.fail('message text is not a string')
+    }
+
+    assert.ok(firstUserMessageText.includes('my-project'))
+    assert.ok(firstUserMessageText.includes('my-tenant'))
+    assert.ok(firstUserMessageText.includes('my-environment'))
+    assert.ok(firstUserMessageText.includes('Please fetch which revision'))
+
+    const firstAssistantMessageText = firstAssistantMessage.content.text
+    if (typeof firstAssistantMessageText !== 'string') {
+      assert.fail('message text is not a string')
+    }
+
+    assert.ok(firstAssistantMessageText.includes('my-project'))
+    assert.ok(firstAssistantMessageText.includes('my-tenant'))
+    assert.ok(firstAssistantMessageText.includes('my-environment'))
+    assert.ok(firstAssistantMessageText.includes('to be fetched'))
+  })
+
+  test('the prompt is retrieved including the revisionName', async () => {
+    const result = await client.request(
+      {
+        method: 'prompts/get',
+        params: {
+          name: 'deploy',
+          arguments: {
+            tenant: 'my-tenant',
+            project: 'my-project',
+            environment: 'my-environment',
+            revisionName: 'my-revision',
+          },
+        },
+      },
+      GetPromptResultSchema,
+    )
+
+    assert.equal(result.messages.length, 3)
+    const [ firstUserMessage, firstAssistantMessage, secondUserMessage ] = result.messages
+    assert.equal(firstUserMessage.role, 'user')
+    assert.equal(firstAssistantMessage.role, 'assistant')
+    assert.equal(secondUserMessage.role, 'user')
+
+    const firstUserMessageText = firstUserMessage.content.text
+    if (typeof firstUserMessageText !== 'string') {
+      assert.fail('message text is not a string')
+    }
+
+    assert.ok(firstUserMessageText.includes('my-revision'))
+
+    const firstAssistantMessageText = firstAssistantMessage.content.text
+    if (typeof firstAssistantMessageText !== 'string') {
+      assert.fail('message text is not a string')
+    }
+
+    assert.ok(firstAssistantMessageText.includes('my-revision'))
+  })
+})

--- a/src/prompts/deploy.ts
+++ b/src/prompts/deploy.ts
@@ -1,0 +1,80 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
+
+import z from 'zod'
+
+export const addDeployPrompt = (server: McpServer) => {
+  server.registerPrompt(
+    'deploy',
+    {
+      title: 'Deploy Mia-Platform project',
+      description: 'Base prompt to deploy a Mia-Platform project',
+      argsSchema: {
+        tenant: z.string().describe('The name or the identifier tenant where the project to deploy is located.'),
+        project: z.string().describe('The name or the identifier of the project to deploy.'),
+        environment: z.string().describe('In which environment the project has to be deployed.'),
+        revisionName: z.string().optional().describe('The name of the revision to deploy. If not provided, the main revision will be used.'),
+      },
+    },
+    async ({ revisionName, environment, project, tenant }) => {
+      const revisionInstruction = revisionName
+        ? `The revision to deploy is called ${revisionName}`
+        : 'Please fetch which revision is the main one to execute the deployment of that configuration'
+
+      const revisionConfirm = revisionName || 'to be fetched'
+
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `Please execute the deployment of project ${project} in tenant ${tenant} to environment ${environment}. ${revisionInstruction}.\n\nAfter the deployment, provide:\n1. The pipeline execution URL.\n2. The deployment status, including whether pods are being created correctly or if there are any errors.`,
+            },
+          },
+          {
+            role: 'assistant',
+            content: {
+              type: 'text',
+              text: `I understand you want me to deploy this project. \
+First I will review the list of available tenants and the list of available projects to be sure that I find the project you want to be developed. \
+If I don't find the tenant or the project, or the environment, I will try to use tools to get \
+the list of available tenants, projects, environments and the revision (if missing or incorrect) to be sure that the parameters you provided are correct. \
+Then, I will validate the configuration, start the deployment, and then return:
+- The pipeline URL
+- The deployment status (pods creation and error checks).
+
+Before proceeding, please confirm these parameters:
+- Project: ${project}
+- Tenant: ${tenant}
+- Environment: ${environment}
+- Revision: ${revisionConfirm}\
+`,
+            },
+          },
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `Yes, proceed.`,
+            },
+          },
+        ],
+      }
+    },
+  )
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,0 +1,18 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { addDeployPrompt } from './deploy'
+
+export { addDeployPrompt }

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -17,7 +17,7 @@ import { suite, test } from 'node:test'
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { ListPromptsResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 
 import { getMcpServer } from './server'
 import { toolsDescriptions } from '../tools/descriptions'
@@ -45,6 +45,15 @@ suite('initialize server', () => {
       ListToolsResultSchema,
     )
     t.assert.equal(toolsResult.tools.length, Object.keys(toolsDescriptions).length, 'should return all the registred tools')
+
+    const promptsResult = await testClient.request(
+      {
+        method: 'prompts/list',
+      },
+      ListPromptsResultSchema,
+    )
+
+    t.assert.equal(promptsResult.prompts.length, 1, 'should return all the registred prompts')
 
     await clientTransport.close()
     await serverTransport.close()

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -13,11 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Implementation } from '@modelcontextprotocol/sdk/types.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { ServerOptions } from '@modelcontextprotocol/sdk/server/index.js'
 import { UndiciHeaders } from 'undici/types/dispatcher'
 
 import { addConfigurationCapabilities } from '../tools/configuration'
 import { addDeployCapabilities } from '../tools/deploy'
+import { addDeployPrompt } from '../prompts'
 import { addGovernanceCapabilities } from '../tools/governance'
 import { addMarketplaceCapabilities } from '../tools/marketplace'
 import { addRuntimeCapabilities } from '../tools/runtime'
@@ -31,26 +34,35 @@ export function getMcpServer (
   clientSecret: string,
   additionalHeaders: UndiciHeaders = {},
 ): McpServer {
-  const server = new McpServer({
+  const implementation: Implementation = {
     name,
     description,
     version,
+  }
+
+  const options: ServerOptions = {
     capabilities: {
       logging: {},
       resources: {},
       prompts: {},
       tools: {},
     },
-  })
+  }
+
+  const server = new McpServer(implementation, options)
 
   const apiClient = new APIClient(host, clientID, clientSecret, additionalHeaders)
 
+  // Tools
   addMarketplaceCapabilities(server, apiClient)
   addGovernanceCapabilities(server, apiClient)
   addServicesCapabilities(server, apiClient)
   addConfigurationCapabilities(server, apiClient)
   addDeployCapabilities(server, apiClient)
   addRuntimeCapabilities(server, apiClient)
+
+  // Prompts
+  addDeployPrompt(server)
 
   return server
 }


### PR DESCRIPTION
## What this PR is for?

This pull request includes the support for prompts inside the Console MCP Server, to have them available when using it with a client that supports them (VS Code, Claude Code, etc).

To use them, this includes a new prompt called `deploy`, that includes a prompt of a conversation between an user and an assistant dedicated to the deploy of a Mia-Platform project.

