### PR TITLE
feat: add `isError` property in tool responses in case of error

### DIFF
--- a/src/tools/configuration/index.test.ts
+++ b/src/tools/configuration/index.test.ts
@@ -103,7 +103,7 @@ suite('list configuration revisions tool', () => {
       }
     })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
 
     const expectedError = 'error fetching project info'
@@ -132,7 +132,7 @@ suite('list configuration revisions tool', () => {
     ])
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
 
@@ -172,7 +172,7 @@ suite('list configuration revisions tool', () => {
     ])
   })
 
-  it('returns revisions and tags', async (t) => {
+  it('returns revisions and tags', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
 
@@ -216,7 +216,7 @@ suite('list configuration revisions tool', () => {
     ])
   })
 
-  it('returns error - if request returns error', async (t) => {
+  it('returns error - if request returns error', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
 
@@ -249,6 +249,7 @@ suite('list configuration revisions tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching revisions or versions: error message',
@@ -268,7 +269,7 @@ suite('get configuration tool', () => {
       return mockConfiguration as unknown as RetrievedConfiguration
     })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const refId = 'main'
 
@@ -291,6 +292,7 @@ suite('get configuration tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching configuration: ${expectedError}`,
@@ -299,7 +301,7 @@ suite('get configuration tool', () => {
     ])
   })
 
-  it('should return error if AI features are not enabled for tenant', async (t) => {
+  it('should return error if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -333,6 +335,7 @@ suite('get configuration tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching configuration: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -341,7 +344,7 @@ suite('get configuration tool', () => {
     ])
   })
 
-  it('should retrieve and return configuration', async (t) => {
+  it('should retrieve and return configuration', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -382,7 +385,7 @@ suite('get configuration tool', () => {
     ])
   })
 
-  it('should return error message if API request fails', async (t) => {
+  it('should return error message if API request fails', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const refId = 'main'
@@ -416,6 +419,7 @@ suite('get configuration tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching configuration: some error',
@@ -435,7 +439,7 @@ suite('configuration save tool', () => {
       return mockSaveResponse
     })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const refId = 'main'
 
@@ -473,6 +477,7 @@ suite('configuration save tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error saving configuration: ${expectedError}`,
@@ -481,7 +486,7 @@ suite('configuration save tool', () => {
     ])
   })
 
-  it('returns error - when AI features are not enabled for tenant', async (t) => {
+  it('returns error - when AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -531,6 +536,7 @@ suite('configuration save tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error saving configuration: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -539,7 +545,7 @@ suite('configuration save tool', () => {
     ])
   })
 
-  it('saves configuration successfully with multiple resource types', async (t) => {
+  it('saves configuration successfully with multiple resource types', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -636,7 +642,7 @@ suite('configuration save tool', () => {
     ])
   })
 
-  it('should return error message if POST request fails', async (t) => {
+  it('should return error message if POST request fails', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const refId = 'main'
@@ -686,6 +692,7 @@ suite('configuration save tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error saving configuration: some error',
@@ -706,7 +713,7 @@ suite('create collection tool', () => {
       return mockSaveResponse
     })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const refId = 'main'
     const collectionName = 'users'
@@ -736,6 +743,7 @@ suite('create collection tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating collection: ${expectedError}`,
@@ -744,7 +752,7 @@ suite('create collection tool', () => {
     ])
   })
 
-  it('returns error - when AI features are not enabled for tenant', async (t) => {
+  it('returns error - when AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -785,6 +793,7 @@ suite('create collection tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating collection: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -793,7 +802,7 @@ suite('create collection tool', () => {
     ])
   })
 
-  it('creates collection successfully', async (t) => {
+  it('creates collection successfully', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -847,7 +856,7 @@ suite('create collection tool', () => {
     ])
   })
 
-  it('should return error message if POST request fails', async (t) => {
+  it('should return error message if POST request fails', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const refId = 'main'
@@ -888,6 +897,7 @@ suite('create collection tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error creating collection: some error',
@@ -905,7 +915,7 @@ suite('create endpoints tool', () => {
     return mockSaveResponse
   })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const refId = 'main'
     const endpointType = 'custom' as const
@@ -934,6 +944,7 @@ suite('create endpoints tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating endpoint "${endpointName}": ${expectedError}`,
@@ -942,7 +953,7 @@ suite('create endpoints tool', () => {
     ])
   })
 
-  it('returns error - when AI features are not enabled for tenant', async (t) => {
+  it('returns error - when AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -982,6 +993,7 @@ suite('create endpoints tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating endpoint "${endpointName}": ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -990,7 +1002,7 @@ suite('create endpoints tool', () => {
     ])
   })
 
-  it('creates custom endpoint successfully', async (t) => {
+  it('creates custom endpoint successfully', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -1038,7 +1050,7 @@ suite('create endpoints tool', () => {
     ])
   })
 
-  it('creates crud endpoint successfully', async (t) => {
+  it('creates crud endpoint successfully', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const refId = 'main'
@@ -1086,7 +1098,7 @@ suite('create endpoints tool', () => {
     ])
   })
 
-  it('should return error message if POST request fails', async (t) => {
+  it('should return error message if POST request fails', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const refId = 'main'
@@ -1126,6 +1138,7 @@ suite('create endpoints tool', () => {
     }, CallToolResultSchema)
 
     t.assert.equal(aiFeaturesMockFn.mock.callCount(), 1)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating endpoint "${endpointName}": some error`,

--- a/src/tools/configuration/index.ts
+++ b/src/tools/configuration/index.ts
@@ -48,6 +48,7 @@ export function addConfigurationCapabilities (server: McpServer, client: IAPICli
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -83,6 +84,7 @@ export function addConfigurationCapabilities (server: McpServer, client: IAPICli
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -126,6 +128,7 @@ export function addConfigurationCapabilities (server: McpServer, client: IAPICli
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -277,6 +280,7 @@ export function addConfigurationCapabilities (server: McpServer, client: IAPICli
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -322,6 +326,7 @@ export function addConfigurationCapabilities (server: McpServer, client: IAPICli
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',

--- a/src/tools/deploy/index.test.ts
+++ b/src/tools/deploy/index.test.ts
@@ -51,7 +51,7 @@ async function getTestMCPServerClient (mocks: APIClientMockFunctions): Promise<C
 }
 
 suite('setup deploy tools', () => {
-  test('should setup deploy tools to a server', async (t) => {
+  test('should setup deploy tools to a server', async (t: it.TestContext) => {
     const client = await TestMCPServer((server) => {
       addDeployCapabilities(server, new APIClientMock({}))
     })
@@ -76,7 +76,7 @@ suite('deploy project tool', () => {
     return triggerDeployResponse
   })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const revision = 'main'
     const environment = 'development'
@@ -103,7 +103,7 @@ suite('deploy project tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error deploying project: ${expectedError}`,
@@ -112,7 +112,7 @@ suite('deploy project tool', () => {
     ])
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const revision = 'main'
@@ -148,7 +148,7 @@ suite('deploy project tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error deploying project: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -157,7 +157,7 @@ suite('deploy project tool', () => {
     ])
   })
 
-  it('triggers a deployment correctly', async (t) => {
+  it('triggers a deployment correctly', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const revision = 'main'
@@ -199,7 +199,7 @@ suite('deploy project tool', () => {
     ])
   })
 
-  it('returns error - if deploy request fails', async (t) => {
+  it('returns error - if deploy request fails', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const revision = 'main'
@@ -233,7 +233,7 @@ suite('deploy project tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error deploying project: error message',
@@ -252,7 +252,7 @@ suite('compare_update_for_deploy tool', () => {
     return compareUpdateResponse
   })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const revision = 'main'
     const environment = 'development'
@@ -279,7 +279,7 @@ suite('compare_update_for_deploy tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error retrieving configuration updates: ${expectedError}`,
@@ -288,7 +288,7 @@ suite('compare_update_for_deploy tool', () => {
     ])
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const revision = 'main'
@@ -324,7 +324,7 @@ suite('compare_update_for_deploy tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error retrieving configuration updates: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -333,7 +333,7 @@ suite('compare_update_for_deploy tool', () => {
     ])
   })
 
-  test('should retrieve configuration updates for deploy', async (t) => {
+  test('should retrieve configuration updates for deploy', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const revision = 'main'
@@ -374,7 +374,7 @@ suite('compare_update_for_deploy tool', () => {
     ])
   })
 
-  test('should return error message if compare update request returns error', async (t) => {
+  test('should return error message if compare update request returns error', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const revision = 'main'
@@ -407,7 +407,7 @@ suite('compare_update_for_deploy tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error retrieving configuration updates: error message',
@@ -428,7 +428,7 @@ suite('deploy_pipeline_status tool', () => {
     return successStatus
   })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const pipelineId = '456'
 
@@ -451,7 +451,7 @@ suite('deploy_pipeline_status tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error deploying project: ${expectedError}`,
@@ -460,7 +460,7 @@ suite('deploy_pipeline_status tool', () => {
     ])
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const pipelineId = '456'
@@ -492,7 +492,7 @@ suite('deploy_pipeline_status tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error deploying project: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -501,7 +501,7 @@ suite('deploy_pipeline_status tool', () => {
     ])
   })
 
-  test('should get pipeline status successfully', async (t) => {
+  test('should get pipeline status successfully', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const pipelineId = '456'
@@ -538,7 +538,7 @@ suite('deploy_pipeline_status tool', () => {
     ])
   })
 
-  test('should return error message if pipeline status request returns error', async (t) => {
+  test('should return error message if pipeline status request returns error', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const pipelineId = '456'
@@ -567,7 +567,7 @@ suite('deploy_pipeline_status tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error deploying project: error message',

--- a/src/tools/governance/index.test.ts
+++ b/src/tools/governance/index.test.ts
@@ -65,7 +65,7 @@ async function getTestMCPServerClient (mocks: APIClientMockFunctions): Promise<C
 }
 
 suite('setup governance tools', () => {
-  test('should setup tools to a server', async (t) => {
+  test('should setup tools to a server', async (t: it.TestContext) => {
     const client = await TestMCPServer((server) => {
       addGovernanceCapabilities(server, new APIClientMock({}))
     })
@@ -82,11 +82,12 @@ suite('setup governance tools', () => {
 })
 
 suite('projects list tool', () => {
-  const aiFeaturesRulesForTenant = {
+  const aiFeaturesRulesForTenant: Record<string, boolean> = {
     tenant1: true,
     tenant2: false,
     tenant3: true,
   }
+
   const aiFeaturesMockFn = mock.fn(async (tenantId: string): Promise<boolean> => {
     if (!(tenantId in aiFeaturesRulesForTenant)) {
       throw new Error(`Tenant ${tenantId} not found`)
@@ -113,7 +114,7 @@ suite('projects list tool', () => {
   })
 
 
-  it('returns only projects from tenants with AI features enabled', async (t) => {
+  it('returns only projects from tenants with AI features enabled', async (t: it.TestContext) => {
     const testTenantIds = [ 'tenant1', 'tenant2' ]
 
     const client = await getTestMCPServerClient({
@@ -141,7 +142,7 @@ suite('projects list tool', () => {
     ])
   })
 
-  it('returns error - if no specified tenant has AI features enabled', async (t) => {
+  it('returns error - if no specified tenant has AI features enabled', async (t: it.TestContext) => {
     const testTenantIds = [ 'tenant2' ]
 
     const client = await getTestMCPServerClient({
@@ -158,7 +159,7 @@ suite('projects list tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching projects for ${testTenantIds.join(', ')}: ${ERR_AI_FEATURES_NOT_ENABLED_MULTIPLE_TENANTS}`,
@@ -167,7 +168,7 @@ suite('projects list tool', () => {
     ])
   })
 
-  it('filters errors when retrieving company AI settings', async (t) => {
+  it('filters errors when retrieving company AI settings', async (t: it.TestContext) => {
     const testTenantIds = [ 'error', 'tenant3' ]
 
     const client = await getTestMCPServerClient({
@@ -196,7 +197,7 @@ suite('projects list tool', () => {
     ])
   })
 
-  it('returns error message if request return error', async (t) => {
+  it('returns error message if request return error', async (t: it.TestContext) => {
     const testTenantIds = [ 'tenant1' ]
 
     const client = await getTestMCPServerClient({
@@ -215,7 +216,7 @@ suite('projects list tool', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching projects for ${testTenantIds.join(', ')}: error message`,
@@ -226,7 +227,7 @@ suite('projects list tool', () => {
 })
 
 suite('get project info', () => {
-  test('returns error - if AI features are not enabled for tenant', async (t) => {
+  test('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
 
@@ -256,7 +257,7 @@ suite('get project info', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching project ${testProjectId}: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -265,7 +266,7 @@ suite('get project info', () => {
     ])
   })
 
-  it('returns project info', async (t) => {
+  it('returns project info', async (t: it.TestContext) => {
     const testTenantId = 'tenantID'
     const testProjectId = 'projectID'
 
@@ -302,7 +303,7 @@ suite('get project info', () => {
     ])
   })
 
-  it('returns error message if request return error', async (t) => {
+  it('returns error message if request return error', async (t: it.TestContext) => {
     const testTenantId = 'tenantID'
     const testProjectId = 'error'
 
@@ -331,7 +332,7 @@ suite('get project info', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching project error: error message',
@@ -342,7 +343,7 @@ suite('get project info', () => {
 })
 
 suite('create project from template', () => {
-  test('returns error - if AI features are not enabled for tenant', async (t) => {
+  test('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
 
     const aiFeaturesMockFn = mock.fn(async (tenantId: string) => {
@@ -366,7 +367,7 @@ suite('create project from template', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating project from template templateID: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -375,7 +376,7 @@ suite('create project from template', () => {
     ])
   })
 
-  test('should create a new project', async (t) => {
+  test('should create a new project', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       createProjectFromTemplateMockFn: async () => project,
       isAiFeaturesEnabledForTenantMockFn: async () => true,
@@ -401,7 +402,7 @@ suite('create project from template', () => {
     ])
   })
 
-  it('returns error message if request return error', async (t) => {
+  it('returns error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       createProjectFromTemplateMockFn: async () => {
         throw new Error('error message')
@@ -421,7 +422,7 @@ suite('create project from template', () => {
       },
     }, CallToolResultSchema)
 
-    t.assert.equal(result.isError, true)
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error creating project from template templateID: error message',
@@ -459,7 +460,7 @@ const auditLogs = [
 ]
 
 suite('companies list tool', () => {
-  const aiFeaturesRulesForTenant = {
+  const aiFeaturesRulesForTenant: Record<string, boolean> = {
     tenant1: true,
     tenant2: false,
     tenant3: true,
@@ -472,7 +473,7 @@ suite('companies list tool', () => {
     return aiFeaturesRulesForTenant[tenantId]
   })
 
-  test('returns only companies with AI features enabled', async (t) => {
+  test('returns only companies with AI features enabled', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       isAiFeaturesEnabledForTenantMockFn: aiFeaturesMockFn,
       listCompaniesMockFn: async () => companies,
@@ -495,7 +496,7 @@ suite('companies list tool', () => {
     ])
   })
 
-  it('returns error - if no tenant has AI features enabled', async (t) => {
+  it('returns error - if no tenant has AI features enabled', async (t: it.TestContext) => {
     const notEnabledCompanies = companies.filter((company) => !aiFeaturesRulesForTenant[company.tenantId])
 
     const client = await getTestMCPServerClient({
@@ -510,6 +511,7 @@ suite('companies list tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching companies: ${ERR_NO_TENANTS_FOUND_WITH_AI_FEATURES_ENABLED}`,
@@ -518,7 +520,7 @@ suite('companies list tool', () => {
     ])
   })
 
-  it('filters companies for which retrieving company AI settings resulted in error', async (t) => {
+  it('filters companies for which retrieving company AI settings resulted in error', async (t: it.TestContext) => {
     const testCompanies = [
       {
         tenantId: 'tenant1',
@@ -557,7 +559,7 @@ suite('companies list tool', () => {
     ])
   })
 
-  it('returns error message if request return error', async (t) => {
+  it('returns error message if request return error', async (t: it.TestContext) => {
     const client = await TestMCPServer((server) => {
       addGovernanceCapabilities(
         server,
@@ -577,6 +579,7 @@ suite('companies list tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching companies: error message',
@@ -587,7 +590,7 @@ suite('companies list tool', () => {
 })
 
 suite('company list template', () => {
-  test('returns error - if AI features are not enabled for tenant', async (t) => {
+  test('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
 
     const aiFeaturesMockFn = mock.fn(async (tenantId: string) => {
@@ -608,6 +611,7 @@ suite('company list template', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching templates for company ${testTenantId}: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -616,7 +620,7 @@ suite('company list template', () => {
     ])
   })
 
-  test('should list templates', async (t) => {
+  test('should list templates', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       companyTemplatesMockFn: async () => templates,
       isAiFeaturesEnabledForTenantMockFn: async () => true,
@@ -639,7 +643,7 @@ suite('company list template', () => {
     ])
   })
 
-  it('returns error message if request return error', async (t) => {
+  it('returns error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       companyTemplatesMockFn: async () => {
         throw new Error('error message')
@@ -656,6 +660,7 @@ suite('company list template', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching templates for company error: error message',
@@ -666,7 +671,7 @@ suite('company list template', () => {
 })
 
 suite('iam list tool', () => {
-  test('returns error - if AI features are not enabled for tenant', async (t) => {
+  test('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
 
     const aiFeaturesMockFn = mock.fn(async (tenantId: string) => {
@@ -687,6 +692,7 @@ suite('iam list tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching IAM for company ${testTenantId}: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -695,7 +701,7 @@ suite('iam list tool', () => {
     ])
   })
 
-  it('returns complete iam list', async (t) => {
+  it('returns complete iam list', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       companyIAMIdentitiesMockFn: async () => iamList,
       isAiFeaturesEnabledForTenantMockFn: async () => true,
@@ -718,7 +724,7 @@ suite('iam list tool', () => {
     ])
   })
 
-  it('returns error message if request return error', async (t) => {
+  it('returns error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       companyIAMIdentitiesMockFn: async () => {
         throw new Error('error message')
@@ -735,6 +741,7 @@ suite('iam list tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching IAM for company error: error message',
@@ -745,7 +752,7 @@ suite('iam list tool', () => {
 })
 
 suite('audit log', () => {
-  test('returns error - if AI features are not enabled for tenant', async (t) => {
+  test('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
 
     const aiFeaturesMockFn = mock.fn(async (tenantId: string) => {
@@ -766,6 +773,7 @@ suite('audit log', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching audit logs for company ${testTenantId}: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -774,7 +782,7 @@ suite('audit log', () => {
     ])
   })
 
-  it('returns audit logs', async (t) => {
+  it('returns audit logs', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       companyAuditLogsMockFn: async () => auditLogs,
       isAiFeaturesEnabledForTenantMockFn: async () => true,
@@ -799,7 +807,7 @@ suite('audit log', () => {
     ])
   })
 
-  it('returns error message if request return error', async (t) => {
+  it('returns error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       companyAuditLogsMockFn: async () => {
         throw new Error('error message')
@@ -816,6 +824,7 @@ suite('audit log', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching audit logs for company error: error message',

--- a/src/tools/governance/index.ts
+++ b/src/tools/governance/index.ts
@@ -191,6 +191,7 @@ export function addGovernanceCapabilities (server: McpServer, client: IAPIClient
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -233,6 +234,7 @@ export function addGovernanceCapabilities (server: McpServer, client: IAPIClient
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -267,6 +269,7 @@ export function addGovernanceCapabilities (server: McpServer, client: IAPIClient
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -302,6 +305,7 @@ export function addGovernanceCapabilities (server: McpServer, client: IAPIClient
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',

--- a/src/tools/marketplace/index.test.ts
+++ b/src/tools/marketplace/index.test.ts
@@ -128,7 +128,7 @@ async function getTestMCPServerClient (mocks: APIClientMockFunctions): Promise<C
 }
 
 suite('setup marketplace tools', () => {
-  test('should setup marketplace tools to a server', async (t) => {
+  test('should setup marketplace tools to a server', async (t: it.TestContext) => {
     const client = await TestMCPServer((server) => {
       addMarketplaceCapabilities(server, new APIClientMock({}))
     })
@@ -152,7 +152,7 @@ suite('marketplace list tool', () => {
     return elements
   })
 
-  test('should return public elements', async (t) => {
+  test('should return public elements', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       listMarketplaceItemsMockFn,
     })
@@ -173,7 +173,7 @@ suite('marketplace list tool', () => {
     ])
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
 
     const aiFeaturesMockFn = mock.fn(async (tenantId: string) => {
@@ -204,7 +204,7 @@ suite('marketplace list tool', () => {
     ])
   })
 
-  test('should return error message if request return error', async (t) => {
+  test('should return error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       isAiFeaturesEnabledForTenantMockFn: async () => true,
       listMarketplaceItemsMockFn,
@@ -221,6 +221,7 @@ suite('marketplace list tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching marketplace items for company error: error message',
@@ -237,7 +238,7 @@ suite('marketplace item versions tool', () => {
     return itemVersions as unknown as CatalogItemRelease[]
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
 
     const aiFeaturesMockFn = mock.fn(async (tenantId: string) => {
@@ -260,6 +261,7 @@ suite('marketplace item versions tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching marketplace item versions for item-id: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -268,7 +270,7 @@ suite('marketplace item versions tool', () => {
     ])
   })
 
-  test('should return item versions', async (t) => {
+  test('should return item versions', async (t: it.TestContext) => {
     const testTenantId = 'tenantID'
 
     const client = await getTestMCPServerClient({
@@ -295,7 +297,7 @@ suite('marketplace item versions tool', () => {
     ])
   })
 
-  test('should return error message if request return error', async (t) => {
+  test('should return error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       isAiFeaturesEnabledForTenantMockFn: async () => true,
       marketplaceItemVersionsMockFn,
@@ -312,6 +314,7 @@ suite('marketplace item versions tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching marketplace item versions for item-id: error message',
@@ -329,7 +332,7 @@ suite('marketplace item version info tool', () => {
     return itemInfo as unknown as CatalogVersionedItem
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
 
     const aiFeaturesMockFn = mock.fn(async (tenantId: string) => {
@@ -353,6 +356,7 @@ suite('marketplace item version info tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching marketplace item info for version 1.0.0: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -361,7 +365,7 @@ suite('marketplace item version info tool', () => {
     ])
   })
 
-  test('should return item version info', async (t) => {
+  test('should return item version info', async (t: it.TestContext) => {
     const testTenantId = 'tenantID'
 
     const client = await getTestMCPServerClient({
@@ -389,7 +393,7 @@ suite('marketplace item version info tool', () => {
     ])
   })
 
-  test('should return error message if request return error', async (t) => {
+  test('should return error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       isAiFeaturesEnabledForTenantMockFn: async () => true,
       marketplaceItemInfoMockFn,
@@ -407,6 +411,7 @@ suite('marketplace item version info tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching marketplace item info for version 1.0.0: error message',
@@ -425,7 +430,7 @@ suite('marketplace Item Type Definitions list tool', async () => {
     return itemTypeDefinitions
   })
 
-  test('should return ITDs', async (t) => {
+  test('should return ITDs', async (t: it.TestContext) => {
     const isAiFeaturesEnabledForTenantMockFn = mock.fn(async () => true)
 
     const client = await getTestMCPServerClient({
@@ -479,7 +484,7 @@ suite('marketplace Item Type Definitions list tool', async () => {
     t.assert.deepEqual(isAiFeaturesEnabledForTenantMockFn.mock.calls.at(1)!.arguments, [ 'my-company' ])
   })
 
-  test('should return ITDs with namespace param if all namespaces have AI features enabled', async (t) => {
+  test('should return ITDs with namespace param if all namespaces have AI features enabled', async (t: it.TestContext) => {
     const isAiFeaturesEnabledForTenantMockFn = mock.fn(async () => true)
 
     const client = await getTestMCPServerClient({
@@ -536,7 +541,7 @@ suite('marketplace Item Type Definitions list tool', async () => {
     t.assert.deepEqual(isAiFeaturesEnabledForTenantMockFn.mock.calls.at(2)!.arguments, [ 'other-company' ])
   })
 
-  test('should return error message if namespace param is used and not all namespaces have AI features enabled', async (t) => {
+  test('should return error message if namespace param is used and not all namespaces have AI features enabled', async (t: it.TestContext) => {
     const isAiFeaturesEnabledForTenantMockFn = mock.fn(async (tenantId: string) => {
       if (tenantId === 'other-company') {
         throw new Error('error message')
@@ -560,6 +565,7 @@ suite('marketplace Item Type Definitions list tool', async () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching marketplace item type definitions: error message',
@@ -572,7 +578,7 @@ suite('marketplace Item Type Definitions list tool', async () => {
     t.assert.deepEqual(isAiFeaturesEnabledForTenantMockFn.mock.calls.at(1)!.arguments, [ 'other-company' ])
   })
 
-  test('should return ITDs filtering out namespaces without AI features enabled', async (t) => {
+  test('should return ITDs filtering out namespaces without AI features enabled', async (t: it.TestContext) => {
     const isAiFeaturesEnabledForTenantMockFn = mock.fn(async (tenantId: string) => {
       if (tenantId === 'my-company') {
         throw new Error('error message')
@@ -626,7 +632,7 @@ suite('marketplace Item Type Definitions list tool', async () => {
     t.assert.deepEqual(isAiFeaturesEnabledForTenantMockFn.mock.calls.at(1)!.arguments, [ 'my-company' ])
   })
 
-  test('should return error message if request return error', async (t) => {
+  test('should return error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       isAiFeaturesEnabledForTenantMockFn: async () => true,
       listMarketplaceItemTypeDefinitionsMockFn,
@@ -640,6 +646,7 @@ suite('marketplace Item Type Definitions list tool', async () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching marketplace item type definitions: error message',
@@ -658,7 +665,7 @@ suite('marketplace Item Type Definition info tool', async () => {
     return itemTypeDefinitions.at(0) as CatalogItemTypeDefinition
   })
 
-  test('should return the ITD', async (t) => {
+  test('should return the ITD', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       isAiFeaturesEnabledForTenantMockFn: async () => true,
       marketplaceItemTypeDefinitionInfoMockFn,
@@ -715,7 +722,7 @@ suite('marketplace Item Type Definition info tool', async () => {
     ])
   })
 
-  it('should return an error if AI features are not enabled for tenant', async (t) => {
+  it('should return an error if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
 
     const aiFeaturesMockFn = mock.fn(async (tenantId: string) => {
@@ -738,6 +745,7 @@ suite('marketplace Item Type Definition info tool', async () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching marketplace Item Type Definition info for namespace ${testTenantId} and name itdName: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -746,7 +754,7 @@ suite('marketplace Item Type Definition info tool', async () => {
     ])
   })
 
-  test('should return error message if request return error', async (t) => {
+  test('should return error message if request return error', async (t: it.TestContext) => {
     const client = await getTestMCPServerClient({
       isAiFeaturesEnabledForTenantMockFn: async () => true,
       marketplaceItemTypeDefinitionInfoMockFn,
@@ -763,6 +771,7 @@ suite('marketplace Item Type Definition info tool', async () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching marketplace Item Type Definition info for namespace error and name itdName: error message',

--- a/src/tools/marketplace/index.ts
+++ b/src/tools/marketplace/index.ts
@@ -66,6 +66,7 @@ export function addMarketplaceCapabilities (server: McpServer, client: IAPIClien
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -100,6 +101,7 @@ export function addMarketplaceCapabilities (server: McpServer, client: IAPIClien
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -139,6 +141,7 @@ export function addMarketplaceCapabilities (server: McpServer, client: IAPIClien
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -227,6 +230,7 @@ export function addMarketplaceCapabilities (server: McpServer, client: IAPIClien
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -265,6 +269,7 @@ export function addMarketplaceCapabilities (server: McpServer, client: IAPIClien
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',

--- a/src/tools/runtime/index.test.ts
+++ b/src/tools/runtime/index.test.ts
@@ -46,7 +46,7 @@ async function getTestMCPServerClient (mocks: APIClientMockFunctions): Promise<C
 }
 
 suite('setup runtime tools', () => {
-  test('should setup runtime tools to a server', async (t) => {
+  test('should setup runtime tools to a server', async (t: it.TestContext) => {
     const client = await TestMCPServer((server) => {
       addRuntimeCapabilities(server, new APIClientMock({}))
     })
@@ -71,7 +71,7 @@ suite('list pods tool', () => {
     return pods
   })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const environmentId = 'test-environment'
 
@@ -102,7 +102,7 @@ suite('list pods tool', () => {
     ])
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const environmentId = 'test-environment'
@@ -134,6 +134,7 @@ suite('list pods tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching pods: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -142,7 +143,7 @@ suite('list pods tool', () => {
     ])
   })
 
-  test('should list pods', async (t) => {
+  test('should list pods', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'test-project'
     const environmentId = 'test-environment'
@@ -179,7 +180,7 @@ suite('list pods tool', () => {
     ])
   })
 
-  test('should return error when pods are not found', async (t) => {
+  test('should return error when pods are not found', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const environmentId = 'test-environment'
@@ -208,6 +209,7 @@ suite('list pods tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: 'Error fetching pods: error message',
@@ -226,7 +228,7 @@ suite('get pod logs tool', () => {
     return logs
   })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
     const environmentId = 'test-environment'
     const podName = 'test-pod'
@@ -253,6 +255,7 @@ suite('get pod logs tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching logs for container ${containerName} in pod ${podName}: ${expectedError}`,
@@ -261,7 +264,7 @@ suite('get pod logs tool', () => {
     ])
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
     const environmentId = 'test-environment'
@@ -297,6 +300,7 @@ suite('get pod logs tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching logs for container ${containerName} in pod ${podName}: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -305,7 +309,7 @@ suite('get pod logs tool', () => {
     ])
   })
 
-  test('should return logs', async (t) => {
+  test('should return logs', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'test-project'
     const environmentId = 'test-environment'
@@ -341,7 +345,7 @@ suite('get pod logs tool', () => {
     t.assert.deepEqual(result.content[0].text, `Logs for container ${containerName} in pod ${podName}: ${logs}`)
   })
 
-  test('should return error when logs are not found', async (t) => {
+  test('should return error when logs are not found', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
     const environmentId = 'test-environment'
@@ -374,6 +378,7 @@ suite('get pod logs tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error fetching logs for container ${containerName} in pod ${podName}: error message`,

--- a/src/tools/runtime/index.ts
+++ b/src/tools/runtime/index.ts
@@ -46,6 +46,7 @@ export function addRuntimeCapabilities (server: McpServer, client: IAPIClient) {
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -83,6 +84,7 @@ export function addRuntimeCapabilities (server: McpServer, client: IAPIClient) {
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',

--- a/src/tools/services/index.test.ts
+++ b/src/tools/services/index.test.ts
@@ -49,7 +49,7 @@ async function getTestMCPServerClient (mocks: APIClientMockFunctions): Promise<C
 }
 
 suite('setup services tools', () => {
-  test('should setup services tools to a server', async (t) => {
+  test('should setup services tools to a server', async (t: it.TestContext) => {
     const client = await TestMCPServer((server) => {
       addServicesCapabilities(server, new APIClientMock({}))
     })
@@ -73,7 +73,7 @@ suite('create service from marketplace tool', () => {
     return saveResponse
   })
 
-  it('returns error - if getProjectInfo fails', async (t) => {
+  it('returns error - if getProjectInfo fails', async (t: it.TestContext) => {
     const testProjectId = 'project123'
 
     const expectedError = 'error fetching project info'
@@ -101,6 +101,7 @@ suite('create service from marketplace tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating ${name} service: ${expectedError}`,
@@ -109,7 +110,7 @@ suite('create service from marketplace tool', () => {
     ])
   })
 
-  it('returns error - if AI features are not enabled for tenant', async (t) => {
+  it('returns error - if AI features are not enabled for tenant', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
 
@@ -146,6 +147,7 @@ suite('create service from marketplace tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating ${name} service: ${ERR_AI_FEATURES_NOT_ENABLED} '${testTenantId}'`,
@@ -154,7 +156,7 @@ suite('create service from marketplace tool', () => {
     ])
   })
 
-  test('should create a service from marketplace item', async (t) => {
+  test('should create a service from marketplace item', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'project123'
 
@@ -196,7 +198,7 @@ suite('create service from marketplace tool', () => {
     ])
   })
 
-  test('should return error when service creation fails', async (t) => {
+  test('should return error when service creation fails', async (t: it.TestContext) => {
     const testTenantId = 'tenant123'
     const testProjectId = 'error-project'
 
@@ -230,6 +232,7 @@ suite('create service from marketplace tool', () => {
       },
     }, CallToolResultSchema)
 
+    t.assert.ok(result.isError)
     t.assert.deepEqual(result.content, [
       {
         text: `Error creating ${name} service: error message`,

--- a/src/tools/services/index.ts
+++ b/src/tools/services/index.ts
@@ -60,6 +60,7 @@ export function addServicesCapabilities (server: McpServer, client: IAPIClient) 
       } catch (error) {
         const err = error as Error
         return {
+          isError: true,
           content: [
             {
               type: 'text',


### PR DESCRIPTION
## What this PR is for?

To follow the requirements of MCP (Version 2025-06-18) regarding [error handling](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling), this PR includes the property `isError` set to `true` in the response of a tool invocation when an exception is catched.